### PR TITLE
Change `max-tokens` default value to be a number

### DIFF
--- a/index.js
+++ b/index.js
@@ -353,7 +353,7 @@ function main() {
         type: "number",
         description:
           "Maximum number of response tokens to generate per response",
-        default: "500",
+        default: 500,
       })
       .option("key", {
         alias: "k",


### PR DESCRIPTION
Resolves #2.

Also tested on 14" MacBook Pro with M1 Pro. It is working as expected ✔️ .